### PR TITLE
Fixed the overlapped strings and the blocked clock string

### DIFF
--- a/app/src/main/res/layout/fragment_timer.xml
+++ b/app/src/main/res/layout/fragment_timer.xml
@@ -28,7 +28,7 @@
             android:gravity="center"
             android:text="@string/timer_time"
             android:textColor="?android:textColorPrimary"
-            android:textSize="65sp"
+            android:textSize="65dp"
             android:textStyle="bold"
             tools:layout_editor_absoluteX="16dp" />
 
@@ -99,16 +99,26 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:text="@string/timer_graph_description"
-        app:layout_constraintStart_toStartOf="@+id/stats_duration_over_time"
+        app:layout_constraintStart_toStartOf="@+id/chart_scrollable_view"
         app:layout_constraintTop_toBottomOf="@+id/view" />
 
-    <com.github.mikephil.charting.charts.LineChart
-        android:id="@+id/stats_duration_over_time"
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:fillViewport="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/timer_stats_trend_icon"
-        tools:layout_editor_absoluteX="16dp" />
+        android:id="@+id/chart_scrollable_view">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/stats_duration_over_time"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                tools:layout_editor_absoluteX="16dp"/>
+        </LinearLayout>
+    </ScrollView>
 
     <ImageView
         android:id="@+id/timer_stats_trend_icon"


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #20, and I have fixed the overlapped strings and the blocked clock string as I mentioned before. It seemed that the chart was located in a very cramped layout so those strings overlapped together, so I used a linear layout inside a scroll view to make this chart scrollable. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/130750847-89884570-9cab-4462-ab19-fad049e525fe.png" alt="copy" width="250"/>

Thanks again! Have a nice day! :)